### PR TITLE
Pass context to createAndroidIcons

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -41,7 +41,7 @@ const create = async (...args) => {
         ? path.resolve(context, options.imagePathAndroid)
         : imagePath;
 
-      await createAndroidIcons(imagePathAndroid, options.android, options.flavor);
+      await createAndroidIcons(imagePathAndroid, options.android, options.flavor, context);
 
       if (options.adaptiveIconBackground && options.adaptiveIconForeground) {
         await createAdaptiveIcons(options, context, options.flavor);


### PR DESCRIPTION
In the absence of this context remains undefined and iconset creation fails with error:
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined