### PR TITLE
Feature/android round icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 tests/**/output
 coverage
 AppTestName
+.idea

--- a/lib/create.js
+++ b/lib/create.js
@@ -41,7 +41,7 @@ const create = async (...args) => {
         ? path.resolve(context, options.imagePathAndroid)
         : imagePath;
 
-      await createAndroidIcons(imagePathAndroid, options.android, options.flavor, context);
+      await createAndroidIcons(imagePathAndroid, options.flavor, context);
 
       if (options.adaptiveIconBackground && options.adaptiveIconForeground) {
         await createAdaptiveIcons(options, context, options.flavor);

--- a/lib/utils/android.js
+++ b/lib/utils/android.js
@@ -10,8 +10,10 @@ const getAndroidResDirectory = (flavor) => `android/app/src/${flavor ?? 'main'}/
 const getAndroidAdaptiveXmlFolder = (flavor) => `${getAndroidResDirectory(flavor)}mipmap-anydpi-v26/`;
 const getAndroidColorsFile = (flavor) => `${getAndroidResDirectory(flavor)}res/values/colors.xml`;
 
+const androidRoundIcon = 'ic_launcher_round';
 const androidAdaptiveForegroundFileName = 'ic_launcher_foreground';
 const androidAdaptiveBackgroundFileName = 'ic_launcher_background';
+const androidIconNames = ['ic_launcher', androidRoundIcon];
 
 const adaptiveForegroundIcons = [
   { directoryName: 'drawable-mdpi', size: 108 },
@@ -52,44 +54,30 @@ const colorsXmlTemplate = `
 </resources>
 `;
 
-exports.createAndroidIcons = (imagePath, iconName, flavor, context) => {
+exports.createAndroidIcons = (imagePath, flavor, context) => {
   return new Promise((resolve, reject) => {
     const androidResDirectory = path.resolve(context, getAndroidResDirectory(flavor));
-
-    if (typeof iconName === 'string') {
-      if (!isAndroidIconNameCorrectFormat(iconName)) {
-        throw new Error('The icon name must contain only lowercase a-z, 0-9, or underscore: \nE.g. "ic_my_new_icon"');
-      }
-
-      log('🚀 Adding a new Android launcher icon');
-    } else {
-      iconName = 'ic_launcher';
-
-      log('Overwriting the default Android launcher icon with a new icon');
-    }
-
     fs.readFile(imagePath, async (err, image) => {
       if (err) {
         return reject(err);
       }
 
-      await overwriteAndroidManifestIcon(iconName, androidManifestFile);
-
-      for (const androidIcon of androidIcons) {
-        const iconDirectory = path.resolve(androidResDirectory, androidIcon.directoryName);
-
-        await saveIcon(image, iconDirectory, iconName, androidIcon);
+      for (const androidIconName of androidIconNames) {
+        for (const androidIcon of androidIcons) {
+          const iconDirectory = path.resolve(androidResDirectory, androidIcon.directoryName);
+          await saveIcon(image, iconDirectory, androidIconName, androidIcon);
+        }
       }
 
       sharp(image)
-        .resize(512, 512)
-        .toFile(path.resolve(androidResDirectory, 'playstore-icon.png'), (err) => {
-          if (err) {
-            return reject(err);
-          }
+          .resize(512, 512)
+          .toFile(path.resolve(androidResDirectory, 'playstore-icon.png'), (err) => {
+            if (err) {
+              return reject(err);
+            }
 
-          resolve();
-        });
+            resolve();
+          });
     });
   });
 };
@@ -179,7 +167,7 @@ const updateColorsFile = (colorsXml, adaptiveIconBackground) => {
 
       if (!foundExisting) {
         lines.splice(lines.length - 1, 0,
-          `\t<color name="ic_launcher_background">${adaptiveIconBackground}</color>`);
+            `\t<color name="ic_launcher_background">${adaptiveIconBackground}</color>`);
       }
 
       fs.writeFileSync(colorsXml, lines.join('\n'));
@@ -192,7 +180,7 @@ const updateColorsFile = (colorsXml, adaptiveIconBackground) => {
 const createAdaptiveIconMipmapXmlFile = (android, flavor, context) => {
   return new Promise((resolve, reject) => {
     const iconName = typeof android === 'string'
-      ? `${android}.xml` : 'ic_launcher.xml';
+        ? `${android}.xml` : 'ic_launcher.xml';
 
     const directory = path.resolve(context, getAndroidAdaptiveXmlFolder(flavor));
 
@@ -222,7 +210,7 @@ const createAdaptiveBackgrounds = (adaptiveIconBackgroundPath, androidResDirecto
       }
 
       const iconName = typeof android === 'string'
-        ? `${android}.xml` : 'ic_launcher.xml';
+          ? `${android}.xml` : 'ic_launcher.xml';
 
       const directory = path.resolve(context, getAndroidAdaptiveXmlFolder(flavor));
 
@@ -250,7 +238,7 @@ const transformAndroidManifestIcon = (oldManifest, iconName) => {
       // escaping the slash to place in string: [^"]*(\\"[^"]*)*"
       // result: any string which does only include escaped quotes
       return line.replace(/android:icon="[^"]*(\\"[^"]*)*"/g,
-        `android:icon="@mipmap/${iconName}"`);
+          `android:icon="@mipmap/${iconName}"`);
     } else {
       return line;
     }
@@ -289,18 +277,30 @@ const isAndroidIconNameCorrectFormat = (iconName) => {
   return /^[a-z0-9_]+$/.exec(iconName);
 };
 
+const getRectForRoundedImage = (size) => new Buffer.from(
+    `<svg><rect x="0" y="0" width="${size}" height="${size}" rx="${size/2}" ry="${size/2}"/></svg>`
+);
+
 const saveIcon = (image, iconDirectory, iconName, androidIcon) => {
   return new Promise((resolve, reject) => {
     createDirectory(iconDirectory);
+    const { size } = androidIcon;
+    const composition = iconName === androidRoundIcon
+        ? [{
+          input: getRectForRoundedImage(size),
+          blend: 'dest-in'
+        }]
+        : [];
 
     sharp(image)
-      .resize(androidIcon.size, androidIcon.size)
-      .toFile(path.resolve(iconDirectory, `${iconName}.png`), (err, info) => {
-        if (err) {
-          return reject(err);
-        }
+        .resize(size)
+        .composite(composition)
+        .toFile(path.resolve(iconDirectory, `${iconName}.png`), (err, info) => {
+          if (err) {
+            return reject(err);
+          }
 
-        resolve(info);
-      });
+          resolve(info);
+        });
   });
 };


### PR DESCRIPTION
Fixes android round icon generation issue. https://github.com/martiliones/icon-set-creator/issues/7

I didn't implement AndroidManifes.xml file replacing functionality since it uses default names for icons (ic_launcher, ic_launcher_round) that's why I think no need to replace them. 