### PR TITLE
Added support for xcode groups & disabling changing the launcher icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ To display all of the options for the given command, run `iconset <command> --he
 
 ```bash
 $ iconset create --help
+
+Usage: index create [options] [image-path]
+
+Generate a new icon set for React Native project
+
+Options:
+  -d, --disable-launcher-icon                  Disable changing the launcher icon for iOS and Android
+  -A, --android [icon-name]                    Generate icon set for android
+  -IPA, --image-path-android                   Image path for android
+  --flavor [flavor]                            Flavor name
+  -b, --adaptive-icon-background <background>  The color (E.g. "#ffffff") or image asset (E.g. "assets/images/christmas-background.png") which will be
+                                               used to fill out the background of the adaptive icon.
+  -f, --adaptive-icon-foreground <foreground>  The image asset which will be used for the icon foreground of the adaptive icon
+  -I, --ios                                    Generate icon set for ios
+  --group <group>                              Group for ios
+  -IPI, --image-path-ios                       Image path for ios
+  -h, --help                                   display help for command
 ```
 
 <h3> Configuration files </h3>
@@ -139,6 +156,7 @@ module.exports = {
 <h4> iconset create </h4>
 
 - `imagePath` — The location of the icon image file which you want to use as the app launcher icon. e.g. `./assets/icon.png`
+- `disableLauncherIcon` - Generate only icons without changing manifest files
 - `android`/`ios` (optional): `true` — Override the default existing React-Native launcher icon for the platform specified, `false` — ignore making launcher icons for this platform, `icon_name` — this will generate a new launcher icons for the platform with the name you specify, without removing the old default existing React-Native launcher icon.
 - `imagePathAndroid` — The location of the icon image file specific for Android platform (optional — if not defined then the `imagePath` is used)
 - `imagePathIos` — The location of the icon image file specific for iOS platform (optional — if not defined then the `imagePath` is used)

--- a/README.md
+++ b/README.md
@@ -106,21 +106,6 @@ To display all of the options for the given command, run `iconset <command> --he
 
 ```bash
 $ iconset create --help
-
-Usage: iconset create [options] [image-path]
-
-Generate a new icon set for React Native project
-
-Options:
-  -A, --android [icon-name]                    Generate icon set for android
-  -IPA, --image-path-android                   Image path for android
-  --flavor [flavor]                            Flavor name
-  -b, --adaptive-icon-background <background>  The color (E.g. "#ffffff") or image asset (E.g. "assets/images/christmas-background.png") which will be used to fill
-                                               out the background of the adaptive icon.
-  -f, --adaptive-icon-foreground <foreground>  The image asset which will be used for the icon foreground of the adaptive icon
-  -I, --ios                                    Generate icon set for ios
-  -IPI, --image-path-ios                       Image path for ios
-  -h, --help                                   display help for command
 ```
 
 <h3> Configuration files </h3>

--- a/index.ts
+++ b/index.ts
@@ -51,6 +51,8 @@ program
   .command('create [image-path]')
   .description('Generate a new icon set for React Native project')
 
+  .option('-d, --disable-launcher-icon', 'Disable changing the launcher icon for iOS and Android')
+
   .option('-A, --android [icon-name]', 'Generate icon set for android')
   .option('-IPA, --image-path-android', 'Image path for android')
   .option('--flavor [flavor]', 'Flavor name')
@@ -59,7 +61,6 @@ program
 
   .option('-I, --ios', 'Generate icon set for ios')
   .option('--group <group>', 'Group for ios')
-  .option('-d, --disable-launcher-icon', 'Disable changing the launcher icon for ios')
   .option('-IPI, --image-path-ios', 'Image path for ios')
   .action((imagePath: string, options) => {
     if (minimist(process.argv.slice(3))._.length > 1) {

--- a/index.ts
+++ b/index.ts
@@ -58,8 +58,8 @@ program
   .option('-f, --adaptive-icon-foreground <foreground>', 'The image asset which will be used for the icon foreground of the adaptive icon')
 
   .option('-I, --ios', 'Generate icon set for ios')
-  .option('--group [group]', 'Group for ios')
-  .option('-d, --disable-change-icon', 'Disable changing the launcher icon for ios')
+  .option('--group <group>', 'Group for ios')
+  .option('-d, --disable-launcher-icon', 'Disable changing the launcher icon for ios')
   .option('-IPI, --image-path-ios', 'Image path for ios')
   .action((imagePath: string, options) => {
     if (minimist(process.argv.slice(3))._.length > 1) {

--- a/index.ts
+++ b/index.ts
@@ -58,6 +58,8 @@ program
   .option('-f, --adaptive-icon-foreground <foreground>', 'The image asset which will be used for the icon foreground of the adaptive icon')
 
   .option('-I, --ios', 'Generate icon set for ios')
+  .option('--group [group]', 'Group for ios')
+  .option('-d, --disable-change-icon', 'Disable changing the launcher icon for ios')
   .option('-IPI, --image-path-ios', 'Image path for ios')
   .action((imagePath: string, options) => {
     if (minimist(process.argv.slice(3))._.length > 1) {

--- a/lib/creator/android.ts
+++ b/lib/creator/android.ts
@@ -24,6 +24,7 @@ import {
 interface AndroidCreatorOptions {
   flavor?: string;
   android?: any;
+  disableLauncherIcon?: boolean;
 }
 
 class AndroidIconCreator {
@@ -60,7 +61,9 @@ class AndroidIconCreator {
           return reject(err);
         }
 
-        await this.overwriteAndroidManifestIcon(iconName!);
+        if (!this.options.disableLauncherIcon) {
+          await this.overwriteAndroidManifestIcon(iconName!);
+        }
 
         for (const androidIcon of androidIcons) {
           const iconDirectory = path.resolve(androidResDirectory, androidIcon.directoryName);

--- a/lib/creator/index.ts
+++ b/lib/creator/index.ts
@@ -86,6 +86,7 @@ export default class Creator {
       const androidIconCreator = new AndroidIconCreator(context, {
         flavor: options.flavor,
         android: options.android,
+        disableLauncherIcon: options.disableLauncherIcon,
       });
 
       await androidIconCreator.createAndroidIcons(imagePathAndroid);

--- a/lib/creator/index.ts
+++ b/lib/creator/index.ts
@@ -14,7 +14,7 @@ interface creatorOptions {
   adaptiveIconBackground?: string;
   adaptiveIconForeground?: string;
   group?: string;
-  disableChangeIcon?: boolean;
+  disableLauncherIcon?: boolean;
 };
 
 export default class Creator {
@@ -103,8 +103,8 @@ export default class Creator {
       const iOSIconCreator = new IOSIconCreator(context, {
         ios: options.ios,
         flavor: options.flavor,
-		group: options.group,
-		disableChangeIcon: options.disableChangeIcon,
+        group: options.group,
+        disableLauncherIcon: options.disableLauncherIcon,
       });
 
       const imagePathIos = options.imagePathIos || options.imagePath;

--- a/lib/creator/index.ts
+++ b/lib/creator/index.ts
@@ -13,6 +13,8 @@ interface creatorOptions {
   flavor?: string;
   adaptiveIconBackground?: string;
   adaptiveIconForeground?: string;
+  group?: string;
+  disableChangeIcon?: boolean;
 };
 
 export default class Creator {
@@ -101,6 +103,8 @@ export default class Creator {
       const iOSIconCreator = new IOSIconCreator(context, {
         ios: options.ios,
         flavor: options.flavor,
+		group: options.group,
+		disableChangeIcon: options.disableChangeIcon,
       });
 
       const imagePathIos = options.imagePathIos || options.imagePath;

--- a/lib/creator/ios.ts
+++ b/lib/creator/ios.ts
@@ -19,7 +19,7 @@ interface IOSCreatorOptions {
   ios?: boolean | string;
   flavor?: string;
   group?: string;
-  disableChangeIcon?: boolean;
+  disableLauncherIcon?: boolean;
 }
 
 class IOSIconCreator {
@@ -47,7 +47,7 @@ class IOSIconCreator {
         let iconName = iosDefaultIconName;
         let catalogName = iosDefaultCatalogName;
 
-        const { flavor, ios } = this.options;
+        const { flavor, ios, disableLauncherIcon } = this.options;
 
         if (flavor) {
           catalogName = `AppIcon-${flavor}`;
@@ -69,9 +69,9 @@ class IOSIconCreator {
           );
         }
 
-		if (!this.options.disableChangeIcon) {
-			await this.changeIosLauncherIcon(catalogName, projectName);
-		} 
+        if (!disableLauncherIcon) {
+          await this.changeIosLauncherIcon(catalogName, projectName);
+        }
 
         this.modifyContentsFile(catalogName, iconName, projectName);
 
@@ -81,9 +81,11 @@ class IOSIconCreator {
   }
 
   getIosProjectName() {
-	if (this.options.group) {
-	  return this.options.group;
-	}
+    const { group } = this.options;
+
+    if (group) {
+      return group;
+    }
 
     const appFilePath = path.resolve(this.context, 'app.json');
 

--- a/lib/creator/ios.ts
+++ b/lib/creator/ios.ts
@@ -18,6 +18,8 @@ import {
 interface IOSCreatorOptions {
   ios?: boolean | string;
   flavor?: string;
+  group?: string;
+  disableChangeIcon?: boolean;
 }
 
 class IOSIconCreator {
@@ -67,7 +69,9 @@ class IOSIconCreator {
           );
         }
 
-        await this.changeIosLauncherIcon(catalogName, projectName);
+		if (!this.options.disableChangeIcon) {
+			await this.changeIosLauncherIcon(catalogName, projectName);
+		} 
 
         this.modifyContentsFile(catalogName, iconName, projectName);
 
@@ -77,6 +81,10 @@ class IOSIconCreator {
   }
 
   getIosProjectName() {
+	if (this.options.group) {
+	  return this.options.group;
+	}
+
     const appFilePath = path.resolve(this.context, 'app.json');
 
     if (fs.existsSync(appFilePath)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icon-set-creator",
-  "version": "1.1.6",
+  "version": "1.2.6",
   "description": "Android & iOS icon generator for React Native",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
There are 2 parts to this pr:
1. Adding support for xcode groups: These are folders within the xcode project. I have a whitelabel app so each app scheme has it's own group. I want to be able to generate the icon for one group at a time. 
2. Disabling changing the launcher icon: When working on a project with multiple schemes changing the launcher icon did it for all schemes. 